### PR TITLE
Update Url for downloading dplz binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Dplz is capable of running shell commands and copying any type of file or direct
 # How to install
 ```bash
 # Get the project using go get
-$ go get github.com/opensourcez/dplz
+$ go get github.com/zveinn/dplz
 # use go to install
 $ go install .
 ```


### PR DESCRIPTION
The old url was for opensourcez github

updating it to zveinn one.